### PR TITLE
fix(explorer): sort group response by id in ascending order

### DIFF
--- a/apps/explorer/src/app/[network]/page.tsx
+++ b/apps/explorer/src/app/[network]/page.tsx
@@ -25,8 +25,10 @@ export default function Network() {
                 validatedProofs: true
             })
 
-            setAllGroups(groups)
-            setFilteredGroups(groups.slice())
+            const sortedGroups = groups.sort((a, b) => parseInt(a.id, 10) - parseInt(b.id, 10))
+
+            setAllGroups(sortedGroups)
+            setFilteredGroups(sortedGroups.slice())
             setLoading(false)
         }
 


### PR DESCRIPTION
previously displayed group response objects inconsistently, change offers better readability to users

<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description

<!-- Describe your changes in detail. -->

Group response objects weren't sorted prior, as a result, the ordering of the items were inconsistent. 

<!-- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
Fix (readability)

<!-- What is the current behavior?** (You can also link to an open issue here) -->

Items now displayed in ascending order by ID on the homepage

![Screenshot 2024-12-10 at 15 11 21](https://github.com/user-attachments/assets/7ddc8a5a-7b5c-4b1b-9364-38d9c2b26d08)

The parseInt function takes a radix as an optional second param, I've used 10 so as to satisfy the linter. Considered using  -   Number(a.id) - Number(b.id) - instead to convert the string to int but for the possibility of it returning NaN. ParseInt will always return a number and therefore minimise further issues arising. 


**Before**

<img width="1407" alt="Screenshot 2024-12-10 at 15 26 23" src="https://github.com/user-attachments/assets/c3b3c272-efb6-4689-8eba-cbd99301ad2c">



**After**

<img width="1411" alt="Screenshot 2024-12-10 at 15 16 53" src="https://github.com/user-attachments/assets/7a3dab0f-692c-4cf0-accf-352ab50374cb">
**
